### PR TITLE
環境構築コマンドの修正

### DIFF
--- a/basic/README.md
+++ b/basic/README.md
@@ -11,7 +11,8 @@
 ### セットアップ
 #### 1. Pipenvを用いて，実行環境の構築・必要なパッケージのインストールを行う
 ```bash
-$ pipenv install
+$ pipenv --python 3.7.2
+$ pipenv install -d
 ```
 
 #### 2. `JupyterLab`を実行する

--- a/basic/README.md
+++ b/basic/README.md
@@ -1,21 +1,24 @@
 # 基本課題
-`JupyterLab`を用いて，ノートブックに書かれている課題に取り組もう。
+JupyterLab を用いて，ノートブックに書かれている課題に取り組もう。
 
 ### `JupyterLab` とは
 プログラムを実行し，実行結果を記録できる Web アプリケーション。
 データ解析や機械学習に最適な統合開発環境である。
 
-> 参考：[JupyterLab 公式HP](https://jupyterlab.readthedocs.io/en/stable/)
+> 参考：[JupyterLab](https://jupyterlab.readthedocs.io/en/stable/)
 
 
 ### セットアップ
-#### 1. Pipenvを用いて，実行環境の構築・必要なパッケージのインストールを行う
+#### 1. Pipenv を用いて，実行環境の構築・必要なパッケージのインストールを行う
 ```bash
 $ pipenv --python 3.7.2
 $ pipenv install -d
 ```
 
-#### 2. `JupyterLab`を実行する
+#### 2. JupyterLab を実行する
 ```bash
 $ pipenv run jupyter lab
 ```
+
+#### 3. JupyterLab 上で課題に取り組む
+JupyterLab 上で `basic.ipynb` を開く。


### PR DESCRIPTION
fixes #8 

## 目的
- 誤った環境構築法を修正する

## 内容
- 明示的に Python のバージョンを指定して環境を構築するようにした
  - パージョンを指定しない場合，Homebrew を用いてインストールした Pipenv を用いると，Homebrew で同時にインストールされた Python によって環境が構築されてしまう
```bash
$ pipenv --python 3.7.2
```

- オプション `-d` をつけることで，`dev-packages` もインストールするようにした
  - 以前はオプションをつけていなかったため，`dev-packages` にある JupyterLab がインストールされていなかった
```bash
$ pipenv install -d
```